### PR TITLE
Minor Fixes - fix #10

### DIFF
--- a/pacifica/notifications/orm.py
+++ b/pacifica/notifications/orm.py
@@ -88,7 +88,7 @@ class EventMatch(Model):
             ret_obj[field_name] = getattr(self, field_name)
         ret_obj['uuid'] = str(ret_obj['uuid'])
         ret_obj['extensions'] = loads(ret_obj['extensions'])
-        for dt_element in ['deleted', 'updated', 'created']:
+        for dt_element in ['disabled', 'deleted', 'updated', 'created']:
             if getattr(self, dt_element):
                 # pylint: disable=no-member
                 ret_obj[dt_element] = getattr(self, dt_element).isoformat()

--- a/pacifica/notifications/rest.py
+++ b/pacifica/notifications/rest.py
@@ -160,7 +160,7 @@ class ReceiveEvent(object):
         """Receive the event and dispatch it to backend."""
         event_obj = loads(cherrypy.request.body.read().decode('utf8'))
         validate(event_obj, cls.event_json_schema)
-        return encode_text(dispatch_event.delay(event_obj))
+        return encode_text(str(dispatch_event.delay(event_obj)))
 # pylint: enable=too-few-public-methods
 
 

--- a/pacifica/notifications/rest.py
+++ b/pacifica/notifications/rest.py
@@ -160,7 +160,7 @@ class ReceiveEvent(object):
         """Receive the event and dispatch it to backend."""
         event_obj = loads(cherrypy.request.body.read().decode('utf8'))
         validate(event_obj, cls.event_json_schema)
-        return str(dispatch_event.delay(event_obj))
+        return encode_text(dispatch_event.delay(event_obj))
 # pylint: enable=too-few-public-methods
 
 


### PR DESCRIPTION
### Description

This makes sure disabled flag in the orm is converted as other
date fields are converted. The receive endpoint also should pass
the output through `encode_text()` method to allow cherrypy to
handle it properly

Signed-off-by: David Brown <dmlb2000@gmail.com>



### Issues Resolved

Fix #10 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
