### PR TITLE
Add config celery section, broker and backend config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,7 @@ env:
 - psql -c 'create database pacifica_metadata;' -U postgres
 - export METADATA_CPCONFIG="$PWD/travis/metadata/server.conf"
 - export POLICY_CPCONFIG="$PWD/travis/policy/server.conf"
+- pacifica-metadata-cmd dbsync
 - pushd travis/metadata; pacifica-metadata & echo $! > metadata.pid; popd;
 - |
   MAX_TRIES=60 HTTP_CODE=$(curl -sL -w "%{http_code}\\n" localhost:8121/keys -o /dev/null || true);

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -41,6 +41,7 @@ before_test:
     $env:POLICY_CPCONFIG = "$PWD/travis/policy/server.conf";
     $env:METADATA_URL = "http://127.0.0.1:8121";
     $env:STATUS_URL = "http://127.0.0.1:8121/groups";
+    pacifica-metadata-cmd dbsync;
     Start-Process C:\pacifica\Scripts\pacifica-metadata.exe -RedirectStandardError metadata-error.log -RedirectStandardOutput metadata-output.log;
     $MD_VERSION = `pip show pacifica-metadata | grep Version: | awk '{ print $2 }';
     Invoke-WebRequest https://github.com/pacifica/pacifica-metadata/archive/v${MD_VERSION}.zip -OutFile pacifica-metadata.zip;

--- a/pacifica/notifications/config.py
+++ b/pacifica/notifications/config.py
@@ -17,14 +17,16 @@ def get_config():
             'default_user'
         )
     })
+    configparser.add_section('celery')
+    configparser.set('celery', 'broker_url', getenv(
+        'BROKER_URL', 'pyamqp://'))
+    configparser.set('celery', 'backend_url', getenv(
+        'BACKEND_URL', 'rpc://'))
+    configparser.add_section('notifications')
+    configparser.set('notifications', 'policy_url', getenv(
+        'POLICY_URL', 'http://127.0.0.1:8181'))
     configparser.add_section('database')
-    configparser.set(
-        'database',
-        'peewee_url',
-        getenv(
-            'PEEWEE_URL',
-            'sqliteext:///db.sqlite3'
-        )
-    )
+    configparser.set('database', 'peewee_url', getenv(
+        'PEEWEE_URL', 'sqliteext:///db.sqlite3'))
     configparser.read(CONFIG_FILE)
     return configparser

--- a/pacifica/notifications/tasks.py
+++ b/pacifica/notifications/tasks.py
@@ -1,19 +1,19 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """The Celery tasks module."""
-from os import getenv
 from datetime import datetime
 from json import dumps
 import requests
 from requests.exceptions import RequestException
 from celery import Celery
-from pacifica.notifications.orm import EventMatch
-from pacifica.notifications.jsonpath import parse, find
+from .orm import EventMatch
+from .jsonpath import parse, find
+from .config import get_config
 
 CELERY_APP = Celery(
     'notifications',
-    broker=getenv('BROKER_URL', 'pyamqp://'),
-    backend=getenv('BACKEND_URL', 'rpc://')
+    broker=get_config().get('celery', 'broker_url'),
+    backend=get_config().get('celery', 'backend_url')
 )
 
 
@@ -48,7 +48,7 @@ def query_policy(eventmatch, event_obj):
     """Query policy server to see if the event should be routed."""
     resp = requests.post(
         '{}/events/{}'.format(
-            getenv('POLICY_URL', 'http://127.0.0.1:8181'),
+            get_config().get('notifications', 'policy_url'),
             eventmatch['user']
         ),
         data=dumps(event_obj),


### PR DESCRIPTION
### Description

This adds a new celery section and additional celery broker and
backend urls. This also removes the get environment references
directly in `tasks` module in favor of the config file.

Signed-off-by: David Brown <dmlb2000@gmail.com>


### Issues Resolved

Fix #16 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
