### PR TITLE
Fix #26 Add Authentication

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,10 +1,10 @@
 repos:
 -   repo: https://github.com/pre-commit/mirrors-autopep8
-    rev: v1.4.3
+    rev: v1.4.4
     hooks:
             -   id: autopep8
 -   repo: git://github.com/pre-commit/pre-commit-hooks
-    rev: v2.0.0
+    rev: v2.1.0
     hooks:
             -   id: fix-encoding-pragma
             -   id: trailing-whitespace

--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -51,6 +51,54 @@ Content-Type: application/json
   "created": "2018-08-02T13:53:05.838827",
   "name": "My Event Match",
   "extensions": {},
+  "auth": {},
+  "target_url": "http://www.example.com/receive",
+  "error": null
+}
+```
+
+#### Create Event Subscription with Authentication
+
+Request:
+```
+POST /eventmatch
+Http-Remote-User: dmlb2001
+Content-Type: application/json
+{
+  "name": "My Event Match",
+  "jsonpath": "data",
+  "auth": {
+    "type": "basic",
+    "basic": {
+      "username": "myusername",
+      "password": "password"
+    }
+  },
+  "target_url": "http://www.example.com/recieve"
+}
+```
+
+Response:
+```
+Content-Type: application/json
+{
+  "user": "dmlb2001",
+  "updated": "2018-08-02T13:53:05.838827",
+  "uuid": "466725b0-cbe1-45cd-b034-c3209aa4b6e0",
+  "deleted": null,
+  "version": "v0.1",
+  "jsonpath": "data",
+  "disabled": null,
+  "created": "2018-08-02T13:53:05.838827",
+  "name": "My Event Match",
+  "extensions": {},
+  "auth": {
+    "type": "basic",
+    "basic": {
+      "username": "myusername",
+      "password": "password"
+    }
+  },
   "target_url": "http://www.example.com/receive",
   "error": null
 }
@@ -79,6 +127,7 @@ Content-Type: application/json
   "created": "2018-08-02T13:53:05.838827",
   "name": "My Event Match",
   "extensions": {},
+  "auth": {},
   "target_url": "http://www.example.com/receive",
   "error": null
 }
@@ -110,6 +159,7 @@ Content-Type: application/json
   "created": "2018-08-02T13:53:05.838827",
   "name": "My Event Match",
   "extensions": {},
+  "auth": {},
   "target_url": "http://api.example.com/receive",
   "error": null
 }

--- a/pacifica/notifications/rest.py
+++ b/pacifica/notifications/rest.py
@@ -58,6 +58,32 @@ class EventMatch(object):
                     'target_url': {'type': 'string'},
                     'version': {'type': 'string'},
                     'extensions': {'type': 'object'},
+                    'auth': {
+                        'type': 'object',
+                        'properties': {
+                            'type': {
+                                'type': 'string',
+                                'enum': ['basic', 'header']
+                            },
+                            'basic': {
+                                'type': 'object',
+                                'properties': {
+                                    'username': {'type': 'string'},
+                                    'password': {'type': 'string'}
+                                },
+                                'required': ['username', 'password']
+                            },
+                            'header': {
+                                'type': 'object',
+                                'properties': {
+                                    'type': {'type': 'string'},
+                                    'credentials': {'type': 'string'}
+                                },
+                                'required': ['type', 'credentials']
+                            },
+                        },
+                        'required': ['type']
+                    },
                     'created': {'type': 'string', 'format': 'date-time'},
                     'updated': {'type': 'string', 'format': 'date-time'},
                     'deleted': {'type': ['string', 'null'], 'format': 'date-time'}
@@ -113,6 +139,7 @@ class EventMatch(object):
         json_obj = loads(cherrypy.request.body.read().decode('utf8'))
         validate(json_obj, cls.json_schema)
         json_obj['extensions'] = dumps(json_obj.get('extensions', {}))
+        json_obj['auth'] = dumps(json_obj.get('auth', {}))
         for key, value in json_obj.items():
             setattr(event_obj, key, value)
         event_obj.updated = datetime.now()
@@ -133,6 +160,7 @@ class EventMatch(object):
         event_match_obj['extensions'] = dumps(
             event_match_obj.get('extensions', {})
         )
+        event_match_obj['auth'] = dumps(event_match_obj.get('auth', {}))
         event_match_obj['user'] = get_remote_user()
         event_obj = orm.EventMatch(**event_match_obj)
         event_obj.validate_jsonpath()

--- a/tests/celery_test.py
+++ b/tests/celery_test.py
@@ -56,7 +56,16 @@ class CeleryCPTest(NotificationsCPTest, helper.CPWebCase):
         """Test the create POST method in EventMatch."""
         resp = self._create_eventmatch(
             headers={'Http-Remote-User': 'dmlb2001'},
-            json_data={'target_url': 'http://127.0.0.1:8192/something/no/where'}
+            json_data={
+                'target_url': 'http://127.0.0.1:8192/something/no/where',
+                'auth': {
+                    'type': 'header',
+                    'header': {
+                        'type': 'Bearer',
+                        'credentials': 'somerandomsharedsecret'
+                    }
+                }
+            }
         )
         eventmatch_obj = resp.json()
         self.assertEqual(eventmatch_obj['user'], 'dmlb2001')

--- a/tests/common_test.py
+++ b/tests/common_test.py
@@ -46,7 +46,14 @@ class NotificationsCPTest(object):
         local_data = {
             'name': 'testevent',
             'jsonpath': '$.data[?(@.value="Blah")].value',
-            'target_url': 'http://127.0.0.1:8080'
+            'target_url': 'http://127.0.0.1:8080',
+            'auth': {
+                'type': 'basic',
+                'basic': {
+                    'username': 'dmlb2001',
+                    'password': 'password'
+                }
+            }
         }
         local_data.update(kwargs.get('json_data', {}))
         return requests.post(


### PR DESCRIPTION
### Description

This adds authentication options to the notifications server.

 - [x] Adds auth storage to the EventMatch object
 - [x] Adds JSONSchema validation for the auth object if present
 - [x] Adds basic types of auth (anything that core requests can handle)

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #26 
### Check List

- [x] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [x] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable
