### PR TITLE
Remove Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 3.6
 dist: xenial
 services:
 - postgresql
@@ -48,18 +49,11 @@ before_script:
 jobs:
   include:
   - stage: lint
-    python: 3.6
-    before_script: skip
-    script: pre-commit run -a
-  - python: 2.7
     before_script: skip
     script: pre-commit run -a
   - stage: test
-    python: 3.6
-  - python: 2.7
   - stage: test-docker
     sudo: required
-    python: 2.7
     services:
     - docker
     before_script: skip
@@ -87,28 +81,13 @@ jobs:
   - stage: deploy
     services: []
     language: python
-    before_install: skip
+    before_script: skip
     script: skip
-    python: 3.6
     deploy:
       skip_cleanup: true
       provider: pypi
       user: dmlb2000
       distributions: sdist bdist_wheel
-      password:
-        secure: unZRE1y5YPkan51bctexTG/KeVVe0deRKzg05sLNFTFzNPPxooOWDStb3AAKfzDl8+cGQmOyWDzQauDXlMUg9g3RPjmSKs5AzxxieP3VAg/gMuw/c5NyGgqcYjW+42ZzLf+xzpbbWddfyaqugvHJCm2MxN3XxC9SpejG3EqpQm2E7DTVq78R6tNrUe/tFybiO92ti6DDF7AZnfNdJkDMUm6mpZuIywyr3RJUv2hixllnUXHNFtbieLKubeSwLd6lXROA39GRUPz1/VrVJ8bFkP9iUufuBcxyAxI12MbFPt8JcVfFnQJaNkHRb+0YAY/Y+nSf21ix9jUNUB9TrbzKj0xAt8iuGt69E+r+idWzg7ruft9zVAOMzR2rJOUOLx6YZY+P430domlZMV2CzZYU265gbseq1sls2DLZwpbDWUo7ANfILEq6phj1h0W17+vlnLzuBufjj9oHWZNLoQnPITsuH0ZBjcmagC3Ck7HvfE8J9DbxWNu+XzNsb9dZRxykzAo65zj5uB/AfQ9h0KGqwYbKvih40RL3d0Xec3D3DjdFkH0n8cAGNhvptAvlfTWIoTD20xqWu0j48hv5882Gi1gVFT8kIqDLOYGbk45bBfj9j9zxdWsHGahQMYJH9ct/4IqE9ftq1PycMOLLAcq14IK7bMJIlyeATVjlmFfv8FM=
-      on:
-        tags: true
-  - services: []
-    language: python
-    before_install: skip
-    script: skip
-    python: 2.7
-    deploy:
-      skip_cleanup: true
-      provider: pypi
-      user: dmlb2000
-      distributions: bdist_wheel
       password:
         secure: unZRE1y5YPkan51bctexTG/KeVVe0deRKzg05sLNFTFzNPPxooOWDStb3AAKfzDl8+cGQmOyWDzQauDXlMUg9g3RPjmSKs5AzxxieP3VAg/gMuw/c5NyGgqcYjW+42ZzLf+xzpbbWddfyaqugvHJCm2MxN3XxC9SpejG3EqpQm2E7DTVq78R6tNrUe/tFybiO92ti6DDF7AZnfNdJkDMUm6mpZuIywyr3RJUv2hixllnUXHNFtbieLKubeSwLd6lXROA39GRUPz1/VrVJ8bFkP9iUufuBcxyAxI12MbFPt8JcVfFnQJaNkHRb+0YAY/Y+nSf21ix9jUNUB9TrbzKj0xAt8iuGt69E+r+idWzg7ruft9zVAOMzR2rJOUOLx6YZY+P430domlZMV2CzZYU265gbseq1sls2DLZwpbDWUo7ANfILEq6phj1h0W17+vlnLzuBufjj9oHWZNLoQnPITsuH0ZBjcmagC3Ck7HvfE8J9DbxWNu+XzNsb9dZRxykzAo65zj5uB/AfQ9h0KGqwYbKvih40RL3d0Xec3D3DjdFkH0n8cAGNhvptAvlfTWIoTD20xqWu0j48hv5882Gi1gVFT8kIqDLOYGbk45bBfj9j9zxdWsHGahQMYJH9ct/4IqE9ftq1PycMOLLAcq14IK7bMJIlyeATVjlmFfv8FM=
       on:

--- a/Dockerfile.celery
+++ b/Dockerfile.celery
@@ -3,7 +3,7 @@ FROM python:3.6
 WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir pymysql psycopg2 cryptography
+RUN pip install --no-cache-dir pymysql psycopg2 cryptography 'celery[redis]' redis
 ENV PEEWEE_PROTO mysql
 ENV PEEWEE_USER notifications
 ENV PEEWEE_PASS notifications

--- a/Dockerfile.uwsgi
+++ b/Dockerfile.uwsgi
@@ -3,7 +3,7 @@ FROM python:3.6
 WORKDIR /usr/src/app
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-RUN pip install --no-cache-dir uwsgi pymysql psycopg2 cryptography
+RUN pip install --no-cache-dir uwsgi pymysql psycopg2 cryptography 'celery[redis]' redis
 ENV PEEWEE_PROTO mysql
 ENV PEEWEE_USER notifications
 ENV PEEWEE_PASS notifications

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,6 @@ environment:
   PEEWEE_URL: postgres://postgres:Password12!@localhost/pacifica_metadata
   BROKER_URL: redis://localhost:6379/0
   matrix:
-  - PYTHON: C:\Python27-x64
   - PYTHON: C:\Python36-x64
 
 install:

--- a/pacifica/notifications/jsonpath.py
+++ b/pacifica/notifications/jsonpath.py
@@ -1,27 +1,14 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
 """The jsonpath interface module."""
-from six import PY2
-# pylint: disable=import-error
-if PY2:  # pragma: no cover only python 2
-    from jsonpath_ng.ext import parse as jsonpath_parse
-else:  # pragma: no cover only python 3
-    from jsonpath2.path import Path
-# pylint: enable=import-error
+from jsonpath2.path import Path
 
-if PY2:  # pragma: no cover only python 2
-    def parse(jsonpath_str):
-        """Parse the jsonpath."""
-        return jsonpath_parse(jsonpath_str)
 
-    def find(expr, data):
-        """Find the expression in the data."""
-        return expr.find(data)
-else:  # pragma: no cover only python 3
-    def parse(jsonpath_str):
-        """Parse the json path."""
-        return Path.parse_str(jsonpath_str)
+def parse(jsonpath_str):
+    """Parse the json path."""
+    return Path.parse_str(jsonpath_str)
 
-    def find(expr, data):
-        """Match the expression in the data."""
-        return expr.match(data)
+
+def find(expr, data):
+    """Match the expression in the data."""
+    return expr.match(data)

--- a/pacifica/notifications/rest.py
+++ b/pacifica/notifications/rest.py
@@ -8,7 +8,6 @@ from jsonschema import validate
 import cherrypy
 from cherrypy import HTTPError
 from peewee import DoesNotExist
-from six import PY2
 from pacifica.notifications import orm
 from pacifica.notifications.config import get_config
 from pacifica.notifications.tasks import dispatch_event
@@ -16,8 +15,6 @@ from pacifica.notifications.tasks import dispatch_event
 
 def encode_text(thing_obj):
     """Encode the text to bytes."""
-    if PY2:  # pragma: no cover only for python 2
-        return str(thing_obj)
     return bytes(thing_obj, 'utf8')  # pragma: no cover only for python 3
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 celery
 cherrypy
+jsonpath2
 jsonschema
 peewee
 requests
 setuptools
-six

--- a/setup.py
+++ b/setup.py
@@ -31,13 +31,5 @@ setup(
             'pacifica-notifications-cmd=pacifica.notifications.__main__:cmd'
         ]
     },
-    install_requires=[str(ir.req) for ir in INSTALL_REQS],
-    extras_require={
-        ':python_version=="2.7"': [
-            'jsonpath-ng'
-        ],
-        ':python_version>="3.0"': [
-            'jsonpath2'
-        ]
-    }
+    install_requires=[str(ir.req) for ir in INSTALL_REQS]
 )


### PR DESCRIPTION
### Description

This removes Python 2.7 from support in Travis CI and Appveyor.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

N/A
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
