### PR TITLE
Add Admin Get Events Command

### DIFF
--- a/docs/exampleusage.md
+++ b/docs/exampleusage.md
@@ -176,3 +176,52 @@ Response:
 ```
 HTTP/1.1 200 OK
 ```
+
+## Command Line Usage
+
+There are several command line options to manage the database schema
+and the data within. There are two commands to verify the schema is
+updated and to update the schema if necessary. There are also
+commands to manage the growing events that are tracked there.
+
+### Schema Management Commands
+
+The database schema can be verified using the `dbchk` subcommand.
+
+```
+$ pacifica-notifications-cmd dbchk; echo $?
+0 or -1
+```
+
+If the result is `-1` then the database is not updated and should be
+updated. To perform this run the `dbsync` subcommand to update the
+schema.
+
+```
+$ pacifica-notifications-cmd dbsync; echo $?
+0
+```
+
+The database schema is now updated and the service can now run.
+
+### Event Log Management
+
+Events and what matches were calculated are logged in the database
+and need to be purged on a regular basis depending on the volume of
+events received. Events can also be queried to view what matches were
+calculated at the time they were received.
+
+```
+$ pacifica-notifications-cmd eventget
+Event - a83ead91-8bff-4819-a0a1-d7dcf430b817
+{...Some event data...}
+    ELM 1791be8f-d9cc-418c-b976-b2a747b58678 (2020-02-29T20:44:17.923416) policy 201 target 200
+    ELM ca028c49-5d87-4ee9-8c2b-620e7c32a10c (2020-02-30T05:13:40.123416) policy 201 target 200
+```
+
+To purge events from the log the `eventpurge` subcommand is used.
+
+```
+$ pacifica-notifications-cmd eventpurge --older-than-date '2020-01-01 00:00:00' --limit 1000; echo $?
+0
+```

--- a/pacifica/notifications/__main__.py
+++ b/pacifica/notifications/__main__.py
@@ -3,12 +3,13 @@
 """The main module for executing the CherryPy server."""
 import os
 from sys import argv as sys_argv
+from datetime import datetime, timedelta
 from time import sleep
 from argparse import ArgumentParser, SUPPRESS
 from threading import Thread
 import cherrypy
 from peewee import OperationalError
-from .orm import OrmSync, NotificationSystem, SCHEMA_MAJOR, SCHEMA_MINOR
+from .orm import OrmSync, NotificationSystem, eventget, eventpurge, SCHEMA_MAJOR, SCHEMA_MINOR
 from .rest import Root, error_page_default
 from .globals import CHERRYPY_CONFIG, CONFIG_FILE
 
@@ -31,19 +32,48 @@ def stop_later(doit=False):
     sleep_thread.start()
 
 
-def cmd(*argv):
-    """Admin command line tool."""
-    parser = ArgumentParser(description='Notifications admin tool.')
-    parser.add_argument(
-        '-c', '--config', metavar='CONFIG', type=str, default=CONFIG_FILE,
-        dest='config', help='notifications config file'
-    )
-    subparsers = parser.add_subparsers(help='sub-command help')
+def bool2cmdint(command_bool):
+    """Convert a boolean to either 0 for true  or -1 for false."""
+    if command_bool:
+        return 0
+    return -1
+
+
+def _eventget(args):
+    """Parse the dates and validate types before calling real eventget."""
+    if not args.start:
+        args.start = (datetime.now() - timedelta(days=1))
+    else:
+        args.start = datetime.strptime(args.start, args.format)
+    if not args.end:
+        args.end = datetime.now()
+    else:
+        args.end = datetime.strptime(args.end, args.format)
+    if args.start > args.end:
+        raise ValueError('Start time {} should be less than end time {}'.format(args.start, args.end))
+    return bool2cmdint(eventget(args))
+
+
+def _eventpurge(args):
+    """Parse the dates and validate types before calling real eventpurge."""
+    if not args.older_than:
+        args.older_than = (datetime.now() - timedelta(days=1))
+    else:
+        args.older_than = datetime.strptime(args.older_than, args.format)
+    return bool2cmdint(eventpurge(args))
+
+
+def _add_dbsync_parser(subparsers):
+    """Add the dbsync subcommand arguments."""
     db_parser = subparsers.add_parser(
         'dbsync',
         description='Update or Create the Database.'
     )
     db_parser.set_defaults(func=dbsync)
+
+
+def _add_dbchk_parser(subparsers):
+    """Add the dbchk subcommand arguments."""
     dbchk_parser = subparsers.add_parser(
         'dbchk',
         description='Check database against current version.'
@@ -53,6 +83,69 @@ def cmd(*argv):
         dest='check_equal', action='store_true'
     )
     dbchk_parser.set_defaults(func=dbchk)
+
+
+def _add_eventget_parser(subparsers):
+    """Add the eventget subcommand arguments."""
+    dbchk_parser = subparsers.add_parser(
+        'eventget',
+        description='Get events from the log.'
+    )
+    dbchk_parser.add_argument(
+        'events', nargs='*', type=str, help='Events to get'
+    )
+    dbchk_parser.add_argument(
+        '--limit', default=10,
+        dest='limit', type=int, help='Number of events to get'
+    )
+    dbchk_parser.add_argument(
+        '--date-format', default='%Y-%m-%d %H:%M:%S',
+        dest='format', type=str, help='Date format for start/end times'
+    )
+    dbchk_parser.add_argument(
+        '--start-date', default=None,
+        dest='start', type=str, help='Start date and time'
+    )
+    dbchk_parser.add_argument(
+        '--end-date', default=None,
+        dest='end', type=str, help='End date and time'
+    )
+    dbchk_parser.set_defaults(func=_eventget)
+
+
+def _add_eventpurge_parser(subparsers):
+    """Add the eventpurge subcommand arguments."""
+    dbchk_parser = subparsers.add_parser(
+        'eventpurge',
+        description='Purge events from the log.'
+    )
+    dbchk_parser.add_argument(
+        'events', nargs='*', type=str, help='Events to purge'
+    )
+    dbchk_parser.add_argument(
+        '--date-format', default='%Y-%m-%d %H:%M:%S',
+        dest='format', type=str, help='Date format for start/end times'
+    )
+    dbchk_parser.add_argument(
+        '--older-than-date', default=None,
+        dest='older_than', type=str, help='Events older than given date'
+    )
+    dbchk_parser.set_defaults(func=_eventpurge)
+
+
+def cmd(*argv):
+    """Admin command line tool."""
+    parser = ArgumentParser(description='Notifications admin tool.')
+    parser.add_argument(
+        '-c', '--config', metavar='CONFIG', type=str, default=CONFIG_FILE,
+        dest='config', help='notifications config file'
+    )
+    parser.set_defaults(func=lambda _args: parser.print_help())
+    subparsers = parser.add_subparsers(help='sub-command help')
+    _add_dbsync_parser(subparsers)
+    _add_dbchk_parser(subparsers)
+    _add_eventget_parser(subparsers)
+    _add_eventpurge_parser(subparsers)
     if not argv:  # pragma: no cover
         argv = sys_argv[1:]
     args = parser.parse_args(argv)
@@ -100,13 +193,6 @@ def main(*argv):
         'server.socket_port': args.port
     })
     cherrypy.quickstart(Root(), '/', args.cpconfig)
-
-
-def bool2cmdint(command_bool):
-    """Convert a boolean to either 0 for true  or -1 for false."""
-    if command_bool:
-        return 0
-    return -1
 
 
 def dbsync(args):


### PR DESCRIPTION
### Description

This adds a command line subcommand `eventget` to query for events
and the event matches they triggered. There are some command line
arguments for querying events and limiting the number of results.

Signed-off-by: David Brown <dmlb2000@gmail.com>

### Issues Resolved

Fix #38 
### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
